### PR TITLE
moved Stream instance for lists (Text.Parsec.String to Text.Parsec.Prim)

### DIFF
--- a/Text/Parsec/Prim.hs
+++ b/Text/Parsec/Prim.hs
@@ -365,6 +365,11 @@ labels p msgs =
 class (Monad m) => Stream s m t | s -> t where
     uncons :: s -> m (Maybe (t,s))
 
+instance (Monad m) => Stream [tok] m tok where
+    uncons []     = return $ Nothing
+    uncons (t:ts) = return $ Just (t,ts)
+    {-# INLINE uncons #-}
+
 tokens :: (Stream s m t, Eq t)
        => ([t] -> String)      -- Pretty print a list of tokens
        -> (SourcePos -> [t] -> SourcePos)

--- a/Text/Parsec/String.hs
+++ b/Text/Parsec/String.hs
@@ -13,7 +13,6 @@
 -----------------------------------------------------------------------------
 
 {-# LANGUAGE FlexibleInstances #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Text.Parsec.String
     ( Parser, GenParser, parseFromFile
@@ -21,11 +20,6 @@ module Text.Parsec.String
 
 import Text.Parsec.Error
 import Text.Parsec.Prim
-
-instance (Monad m) => Stream [tok] m tok where
-    uncons []     = return $ Nothing
-    uncons (t:ts) = return $ Just (t,ts)
-    {-# INLINE uncons #-}
 
 type Parser = Parsec String ()
 type GenParser tok st = Parsec [tok] st


### PR DESCRIPTION
I think Text.Parsec.Prim is a more natural place for this, since it's now adjacent to the typeclass definition  (and as such, Text.Parsec.String doesn't use orphan instances now, either).

I had some trouble finding this instance while using parsec on a custom token type.  Since I didn't want to deal with conflicting names, I didn't want to import Text.Parsec or Text.Parsec.String directly. (although, I did eventually import Text.Parsec.String (), which works).

I think this change will make it easier for others to find the instance.
