### PR TITLE
Support for CRLF line breaks

### DIFF
--- a/Text/Parsec/Char.hs
+++ b/Text/Parsec/Char.hs
@@ -62,13 +62,13 @@ crlf :: (Stream s m Char) => ParsecT s u m Char
 crlf                = char '\r' *> char '\n' <?> "crlf new-line"
 
 -- | Parses a CRLF (see 'crlf') or LF (see 'newline') end-of-line.
--- Returns a newline character.
+-- Returns a newline character (\'\\n\').
 --
--- > anyNewline = newline <|> crlf
+-- > endOfLine = newline <|> crlf
 --
 
-anyNewline :: (Stream s m Char) => ParsecT s u m Char
-anyNewline          = newline <|> crlf       <?> "new-line"
+endOfLine :: (Stream s m Char) => ParsecT s u m Char
+endOfLine           = newline <|> crlf       <?> "new-line"
 
 -- | Parses a tab character (\'\\t\'). Returns a tab character. 
 


### PR DESCRIPTION
I - as many others - write parsers that run on different systems. Windows uses CRLF line breaks while Unix uses just LF. Currently, the `newline` parser only succeeds for LF line breaks. This leads to parsers that fail on one system but not the other, which is annoying.

In my software, I frequently add the parsers I have attached in this pull request. I thought that they may be useful for other users of parsec. Basically, I am just adding CRLF line break support and a `anyNewline` parser, which succeeds for both LF and CRLF line breaks.

If there is any concern about the names, they can be modified.
