### PR TITLE
Bump text upper version bounds

### DIFF
--- a/parsec.cabal
+++ b/parsec.cabal
@@ -60,6 +60,6 @@ library
         build-depends: base >= 3.0.3 && < 4
         cpp-options: -DBASE3
 
-    build-depends: mtl, bytestring, text >= 0.2 && < 1.2
+    build-depends: mtl, bytestring, text >= 0.2 && < 1.3
     extensions:	ExistentialQuantification, PolymorphicComponents, MultiParamTypeClasses, FlexibleInstances, FlexibleContexts, DeriveDataTypeable, CPP
     ghc-options:	-O2


### PR DESCRIPTION
Allow `parsec` to use `text-1.2.0.0`.
