### PR TITLE
Add an Eq instance for ParseError

### DIFF
--- a/Text/Parsec/Error.hs
+++ b/Text/Parsec/Error.hs
@@ -91,7 +91,7 @@ messageString (Message     s) = s
 -- provides the source position ('SourcePos') of the error
 -- and a list of error messages ('Message'). A @ParseError@
 -- can be returned by the function 'Text.Parsec.Prim.parse'. @ParseError@ is an
--- instance of the 'Show' class. 
+-- instance of the 'Show' and 'Eq' classes.
 
 data ParseError = ParseError !SourcePos [Message]
 
@@ -151,6 +151,12 @@ instance Show ParseError where
           showErrorMessages "or" "unknown parse error"
                             "expecting" "unexpected" "end of input"
                            (errorMessages err)
+
+instance Eq ParseError where
+    l == r
+        = errorPos l == errorPos r && messageStrs l == messageStrs r
+        where
+          messageStrs = map messageString . errorMessages
 
 -- Language independent show function
 


### PR DESCRIPTION
I see no reason not to include it, and not having it makes writing some unit-tests unnecessarily cumbersome.

The `Eq` instance for `Message` ignores the message string, so I preferred to write a manual instance for `ParseError` that takes it into account, as otherwise it could be a surprising behaviour.
