### PR TITLE
Add more general primitive combinator.

### DIFF
--- a/Text/Parsec/Prim.hs
+++ b/Text/Parsec/Prim.hs
@@ -45,6 +45,7 @@ module Text.Parsec.Prim
     , token
     , tokenPrim
     , tokenPrimEx
+    , tokenPrimEx'
     , many
     , skipMany
     , manyAccum
@@ -537,31 +538,44 @@ tokenPrimEx :: (Stream s m t)
             -> (t -> Maybe a)     
             -> ParsecT s u m a
 {-# INLINE tokenPrimEx #-}
-tokenPrimEx showToken nextpos Nothing test
+tokenPrimEx showToken nextpos nextState test = tokenPrimEx' errMsg nextpos nextState test' where
+    errMsg c pos _ = unexpectError (showToken c) pos
+    test' x = case test x of
+      Just x' -> Right x'
+      Nothing -> Left ()
+
+tokenPrimEx' :: (Stream s m t)
+             => (t -> SourcePos -> e -> ParseError)
+             -> (SourcePos -> t -> s -> SourcePos)
+             -> Maybe (SourcePos -> t -> s -> u -> u)
+             -> (t -> Either e a)
+             -> ParsecT s u m a
+{-# INLINE tokenPrimEx' #-}
+tokenPrimEx' errMsg nextpos Nothing test
   = ParsecT $ \(State input pos user) cok cerr eok eerr -> do
       r <- uncons input
       case r of
         Nothing -> eerr $ unexpectError "" pos
         Just (c,cs)
          -> case test c of
-              Just x -> let newpos = nextpos pos c cs
-                            newstate = State cs newpos user
-                        in seq newpos $ seq newstate $
-                           cok x newstate (newErrorUnknown newpos)
-              Nothing -> eerr $ unexpectError (showToken c) pos
-tokenPrimEx showToken nextpos (Just nextState) test
+              Right x -> let newpos = nextpos pos c cs
+                             newstate = State cs newpos user
+                         in seq newpos $ seq newstate $
+                            cok x newstate (newErrorUnknown newpos)
+              Left e -> eerr $ errMsg c pos e
+tokenPrimEx' errMsg nextpos (Just nextState) test
   = ParsecT $ \(State input pos user) cok cerr eok eerr -> do
       r <- uncons input
       case r of
         Nothing -> eerr $ unexpectError "" pos
         Just (c,cs)
          -> case test c of
-              Just x -> let newpos = nextpos pos c cs
-                            newUser = nextState pos c cs user
-                            newstate = State cs newpos newUser
-                        in seq newpos $ seq newstate $
-                           cok x newstate $ newErrorUnknown newpos
-              Nothing -> eerr $ unexpectError (showToken c) pos
+              Right x -> let newpos = nextpos pos c cs
+                             newUser = nextState pos c cs user
+                             newstate = State cs newpos newUser
+                         in seq newpos $ seq newstate $
+                            cok x newstate $ newErrorUnknown newpos
+              Left e -> eerr $ errMsg c pos e
 
 unexpectError msg pos = newErrorMessage (SysUnExpect msg) pos
 


### PR DESCRIPTION
I came across a need for a more general primitive combinator than `tokenPrimEx` when parsing more complicated structures than characters. In that case, the `test` function argument may return more information in the error case. The new `tokenPrimEx'` (any ideas for a better name?) takes a function that returns `Either` instead of `Maybe` to allow for any type (instead of `Nothing`) as error information. The `errMsg` function argument (formerly `showToken`) is also more general so it takes the token, position and error type and returns a `ParseError`.

It's easy to define `tokenPrimEx` in terms of `tokenPrimEx'` where the error type is ().
