### PR TITLE
Make example work

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ with the `ghci` command).
 
 ```
 Prelude> :m +Text.Parsec
-Prelude Text.Parsec> let parenSet = char '(' >> many parenSet >> char ')'
+Prelude Text.Parsec> let parenSet = char '(' >> many parenSet >> char ')' :: Parsec String () Char
 Loading package transformers-0.3.0.0 ... linking ... done.
 Loading package array-0.5.0.0 ... linking ... done.
 Loading package deepseq-1.3.0.2 ... linking ... done.


### PR DESCRIPTION
It would be great to see the front page example work again - this change accomplishes that. A note is that the second function definition in the example works as-is, which is to say no type information must be included for that function. 