### PR TITLE
Bump upper bound on base to < 4.13

### DIFF
--- a/parsec.cabal
+++ b/parsec.cabal
@@ -64,7 +64,7 @@ library
         Text.ParserCombinators.Parsec.Token
 
     build-depends:
-        base       >= 4.5.0   && < 4.12,
+        base       >= 4.5.0   && < 4.13,
         mtl        >= 1.1.1   && < 2.3,
         bytestring >= 0.9.2.1 && < 0.11,
         text       >= 0.11.3  && < 1.3


### PR DESCRIPTION
See https://ghc.haskell.org/trac/ghc/ticket/15018.