### PR TITLE
Export `GenLanguageDef` constructor from `Text.Parsec.Language`

### DIFF
--- a/src/Text/Parsec/Language.hs
+++ b/src/Text/Parsec/Language.hs
@@ -22,7 +22,7 @@ module Text.Parsec.Language
     , haskellStyle
     , javaStyle
     , LanguageDef
-    , GenLanguageDef
+    , GenLanguageDef(..)
     ) where
 
 import Text.Parsec


### PR DESCRIPTION
The hidden constructor suggested that it wasn't included in the API,
although `Text.Parsec.Token` does export it.