### PR TITLE
Improve header documentation for Perm.hs

### DIFF
--- a/src/Text/Parsec/Perm.hs
+++ b/src/Text/Parsec/Perm.hs
@@ -23,6 +23,12 @@
 -- by Arthur Baars, Andres Loh and Doaitse Swierstra.
 -- Published as a functional pearl at the Haskell Workshop 2001.
 --
+-- From the abstract: 
+--
+-- A permutation phrase is a sequence of elements (possibly of different types) 
+-- in which each element occurs exactly once and the order is irrelevant. 
+-- Some of the permutable elements may be optional.
+--
 -----------------------------------------------------------------------------
 
 


### PR DESCRIPTION
This is only a documentation change. The meaning of "permutation" isn't exactly clear from reading the header page on Hackage. That meaning is clarified in the first two sentences of the abstract, so I brought those over so others don't have to hunt down the meaning in the paper themselves.