### PR TITLE
Adding parseFromFile and changing String by Filepath

### DIFF
--- a/src/Text/Parsec/ByteString.hs
+++ b/src/Text/Parsec/ByteString.hs
@@ -36,7 +36,7 @@ type GenParser t st = Parsec C.ByteString st
 -- >                  Right xs  -> print (sum xs)
 -- >              }
 
-parseFromFile :: Parser a -> String -> IO (Either ParseError a)
+parseFromFile :: Parser a -> FilePath -> IO (Either ParseError a)
 parseFromFile p fname
     = do input <- C.readFile fname
          return (runP p () fname input)

--- a/src/Text/Parsec/ByteString/Lazy.hs
+++ b/src/Text/Parsec/ByteString/Lazy.hs
@@ -35,7 +35,8 @@ type GenParser t st = Parsec C.ByteString st
 -- >                  Left err  -> print err
 -- >                  Right xs  -> print (sum xs)
 -- >              }
-parseFromFile :: Parser a -> String -> IO (Either ParseError a)
+
+parseFromFile :: Parser a -> FilePath -> IO (Either ParseError a)
 parseFromFile p fname
     = do input <- C.readFile fname
          return (runP p () fname input)

--- a/src/Text/Parsec/String.hs
+++ b/src/Text/Parsec/String.hs
@@ -33,7 +33,7 @@ type GenParser tok st = Parsec [tok] st
 -- >                  Left err  -> print err
 -- >                  Right xs  -> print (sum xs)
 -- >              }
-parseFromFile :: Parser a -> String -> IO (Either ParseError a)
+parseFromFile :: Parser a -> FilePath -> IO (Either ParseError a)
 parseFromFile p fname
     = do input <- readFile fname
          return (runP p () fname input)

--- a/src/Text/Parsec/Text.hs
+++ b/src/Text/Parsec/Text.hs
@@ -15,11 +15,28 @@
 -----------------------------------------------------------------------------
 
 module Text.Parsec.Text
-    ( Parser, GenParser
+    ( Parser, GenParser, parseFromFile
     ) where
 
 import qualified Data.Text as Text
 import Text.Parsec.Prim
+import Text.Parsec.Error
+import Data.Text.IO as T
 
 type Parser = Parsec Text.Text ()
 type GenParser st = Parsec Text.Text st
+
+-- | @parseFromFile p filePath@ runs a strict text parser @p@ on the
+-- input read from @filePath@ using 'Data.Text.IO.readFile'. Returns either a 'ParseError'
+-- ('Left') or a value of type @a@ ('Right').
+--
+-- >  main    = do{ result <- parseFromFile numbers "digits.txt"
+-- >              ; case result of
+-- >                  Left err  -> print err
+-- >                  Right xs  -> print (sum xs)
+-- >              }
+
+parseFromFile :: Parser a -> FilePath -> IO (Either ParseError a)
+parseFromFile p fname
+    = do input <- T.readFile fname
+         return (runP p () fname input)

--- a/src/Text/Parsec/Text/Lazy.hs
+++ b/src/Text/Parsec/Text/Lazy.hs
@@ -15,11 +15,28 @@
 -----------------------------------------------------------------------------
 
 module Text.Parsec.Text.Lazy
-    ( Parser, GenParser
+    ( Parser, GenParser, parseFromFile
     ) where
 
 import qualified Data.Text.Lazy as Text
 import Text.Parsec.Prim
+import Text.Parsec.Error
+import Data.Text.Lazy.IO as TL
 
 type Parser = Parsec Text.Text ()
 type GenParser st = Parsec Text.Text st
+
+-- | @parseFromFile p filePath@ runs a strict text parser @p@ on the
+-- input read from @filePath@ using 'Data.Text.Lazy.IO.readFile'. Returns either a 'ParseError'
+-- ('Left') or a value of type @a@ ('Right').
+--
+-- >  main    = do{ result <- parseFromFile numbers "digits.txt"
+-- >              ; case result of
+-- >                  Left err  -> print err
+-- >                  Right xs  -> print (sum xs)
+-- >              }
+
+parseFromFile :: Parser a -> FilePath -> IO (Either ParseError a)
+parseFromFile p fname
+    = do input <- TL.readFile fname
+         return (runP p () fname input)


### PR DESCRIPTION
Adding `parseFromFile` to Text and changing `String` by its synonym `FilePath `

Fix #103 