### PR TITLE
Changing  documentation for alphaNum

### DIFF
--- a/src/Text/Parsec/Char.hs
+++ b/src/Text/Parsec/Char.hs
@@ -101,7 +101,7 @@ alphaNum :: (Stream s m Char => ParsecT s u m Char)
 alphaNum            = satisfy isAlphaNum    <?> "letter or digit"
 
 -- | Parses an alphabetic Unicode characters (lower-case, upper-case and title-case letters,
--- plus letters of caseless scripts and modifiers letters to 'isAlpha').
+-- plus letters of caseless scripts and modifiers letters according to 'isAlpha').
 -- Returns the parsed character.
 
 letter :: (Stream s m Char) => ParsecT s u m Char

--- a/src/Text/Parsec/Char.hs
+++ b/src/Text/Parsec/Char.hs
@@ -91,11 +91,10 @@ lower               = satisfy isLower       <?> "lowercase letter"
 
 -- | Parses a alphabetic or numeric Unicode characters
 -- according to 'isAlphaNum'. Returns the parsed character.
-
--- | Note that numeric digits outside the ASCII range(such as arabic-indic digits like ٤),
+--
+-- Note that numeric digits outside the ASCII range (such as arabic-indic digits like e.g. \"٤\" or @U+0664@),
 -- as well as numeric characters which aren't digits, are parsed by this function
--- but not by 'digit'. (such characters may be part of identifiers but are not
--- used by the printer and reader to represent numbers).
+-- but not by 'digit'.
 
 alphaNum :: (Stream s m Char => ParsecT s u m Char)
 alphaNum            = satisfy isAlphaNum    <?> "letter or digit"
@@ -107,7 +106,7 @@ alphaNum            = satisfy isAlphaNum    <?> "letter or digit"
 letter :: (Stream s m Char) => ParsecT s u m Char
 letter              = satisfy isAlpha       <?> "letter"
 
--- | Parses a digit. Returns the parsed character.
+-- | Parses an ASCII digit. Returns the parsed character.
 
 digit :: (Stream s m Char) => ParsecT s u m Char
 digit               = satisfy isDigit       <?> "digit"

--- a/src/Text/Parsec/Char.hs
+++ b/src/Text/Parsec/Char.hs
@@ -89,14 +89,20 @@ upper               = satisfy isUpper       <?> "uppercase letter"
 lower :: (Stream s m Char) => ParsecT s u m Char
 lower               = satisfy isLower       <?> "lowercase letter"
 
--- | Parses a letter or digit (a character between \'0\' and \'9\')
+-- | Parses a alphabetic or numeric Unicode characters
 -- according to 'isAlphaNum'. Returns the parsed character.
+
+-- | Note that numeric digits outside the ASCII range(such as arabic-indic digits like ٤),
+-- as well as numeric characters which aren't digits, are parsed by this function
+-- but not by 'digit'. (such characters may be part of identifiers but are not
+-- used by the printer and reader to represent numbers).
 
 alphaNum :: (Stream s m Char => ParsecT s u m Char)
 alphaNum            = satisfy isAlphaNum    <?> "letter or digit"
 
--- | Parses a letter (an upper case or lower case character according
--- to 'isAlpha'). Returns the parsed character.
+-- | Parses an alphabetic Unicode characters (lower-case, upper-case and title-case letters,
+-- plus letters of caseless scripts and modifiers letters to 'isAlpha').
+-- Returns the parsed character.
 
 letter :: (Stream s m Char) => ParsecT s u m Char
 letter              = satisfy isAlpha       <?> "letter"


### PR DESCRIPTION
Trying to fix #98 
I change the documentation of `alphaNum` and `letter` (similar problem to `alphaNum`).

Actually, `letter` parses an alphabetic Unicode characters according to `isAlpha`. Thus, i think that would be better to define a new function `alpha`(according to `isAlpha`) and modify `letter` to parse an upper case or lower case ascii character(according to its documentation).
What do you think? @hvr 
