### PR TITLE
Fix #109: allow semigroups-0.19 in tests too

### DIFF
--- a/parsec.cabal
+++ b/parsec.cabal
@@ -124,4 +124,4 @@ test-suite parsec.
     if impl(ghc >= 8.0)
         ghc-options: -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances
     else
-        build-depends: semigroups == 0.18.*
+        build-depends: semigroups


### PR DESCRIPTION
Yet, the tests on old GHC won't pick semigroups-0.19 as https://github.com/haskell/test-framework/pull/45 is not released. (there is an install plan, if you constraint, using older test-framework).