### PR TITLE
Correct wording in `natural` docstring to be consistent with behaviour

### DIFF
--- a/src/Text/Parsec/Token.hs
+++ b/src/Text/Parsec/Token.hs
@@ -171,7 +171,7 @@ data GenTokenParser s u m
 
         stringLiteral    :: ParsecT s u m String,
 
-        -- | This lexeme parser parses a natural number (a positive whole
+        -- | This lexeme parser parses a natural number (a non-negative whole
         -- number). Returns the value of the number. The number can be
         -- specified in 'decimal', 'hexadecimal' or
         -- 'octal'. The number is parsed according to the grammar


### PR DESCRIPTION
The `natural` parser states that it parses a "positive whole number" which would exclude zero as zero is not a positive number, while its actual behaviour accepts zero. This updates the docstring to match the behaviour, which is correct.