### PR TITLE
Bump base upper bound to 4.16

### DIFF
--- a/parsec.cabal
+++ b/parsec.cabal
@@ -64,7 +64,7 @@ library
         Text.ParserCombinators.Parsec.Token
 
     build-depends:
-        base       >= 4.5.0   && < 4.16,
+        base       >= 4.5.0   && < 4.17,
         mtl        >= 1.1.1   && < 2.3,
         bytestring >= 0.9.2.1 && < 0.11,
         text      (>= 0.11.3.1 && < 0.12)

--- a/parsec.cabal
+++ b/parsec.cabal
@@ -64,7 +64,7 @@ library
         Text.ParserCombinators.Parsec.Token
 
     build-depends:
-        base       >= 4.5.0   && < 4.15,
+        base       >= 4.5.0   && < 4.16,
         mtl        >= 1.1.1   && < 2.3,
         bytestring >= 0.9.2.1 && < 0.11,
         text      (>= 0.11.3.1 && < 0.12)


### PR DESCRIPTION
Context: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4082#note_300462