### PR TITLE
Allow text-2.0

### DIFF
--- a/parsec.cabal
+++ b/parsec.cabal
@@ -117,9 +117,8 @@ test-suite parsec.
         mtl,
         parsec,
         -- dependencies whose version bounds are not inherited via lib:parsec
-        HUnit                == 1.6.* || (>= 1.3.1.2 && < 1.4),
-        test-framework       == 0.8.*,
-        test-framework-hunit == 0.3.*
+        tasty >= 1.4 && < 1.5,
+        tasty-hunit >= 0.10 && < 0.11
 
     default-language: Haskell2010
 

--- a/parsec.cabal
+++ b/parsec.cabal
@@ -69,6 +69,7 @@ library
         bytestring >= 0.9.2.1 && < 0.12,
         text      (>= 0.11.3.1 && < 0.12)
                || (>= 1.0.0.0  && < 1.3)
+               || (>= 2.0 && < 2.1)
 
     default-language: Haskell2010
     other-extensions:

--- a/test/Bugs.hs
+++ b/test/Bugs.hs
@@ -3,14 +3,14 @@ module Bugs
        ( bugs
        ) where
 
-import Test.Framework
+import Test.Tasty
 
 import qualified Bugs.Bug2
 import qualified Bugs.Bug6
 import qualified Bugs.Bug9
 import qualified Bugs.Bug35
 
-bugs :: [Test]
+bugs :: [TestTree]
 bugs = [ Bugs.Bug2.main
        , Bugs.Bug6.main
        , Bugs.Bug9.main

--- a/test/Bugs/Bug2.hs
+++ b/test/Bugs/Bug2.hs
@@ -3,16 +3,15 @@ module Bugs.Bug2
        ( main
        ) where
 
-import Test.HUnit hiding ( Test )
-import Test.Framework
-import Test.Framework.Providers.HUnit
+import Test.Tasty
+import Test.Tasty.HUnit
 
 import Text.Parsec
 import Text.Parsec.String
 import qualified Text.Parsec.Token as P
 import Text.Parsec.Language (haskellDef)
 
-main :: Test
+main :: TestTree
 main =
   testCase "Control Char Parsing (#2)" $
   parseString "\"test\\^Bstring\"" @?= "test\^Bstring"

--- a/test/Bugs/Bug35.hs
+++ b/test/Bugs/Bug35.hs
@@ -6,9 +6,8 @@ import Text.Parsec.Language
 import Text.Parsec.String
 import qualified Text.Parsec.Token as Token
 
-import Test.HUnit hiding (Test)
-import Test.Framework
-import Test.Framework.Providers.HUnit
+import Test.Tasty
+import Test.Tasty.HUnit
 
 trickyFloats :: [String]
 trickyFloats =
@@ -36,5 +35,5 @@ testBatch :: Assertion
 testBatch = mapM_ testFloat trickyFloats
     where testFloat x = parse float "" x @?= Right (read x :: Double)
 
-main :: Test
+main :: TestTree
 main = testCase "Quality of output of Text.Parsec.Token.float (#35)" testBatch

--- a/test/Bugs/Bug6.hs
+++ b/test/Bugs/Bug6.hs
@@ -3,16 +3,15 @@ module Bugs.Bug6
        ( main
        ) where
 
-import Test.HUnit hiding ( Test )
-import Test.Framework
-import Test.Framework.Providers.HUnit
+import Test.Tasty
+import Test.Tasty.HUnit
 
 import Text.Parsec
 import Text.Parsec.String
 
 import Util
 
-main :: Test
+main :: TestTree
 main =
   testCase "Look-ahead preserving error location (#6)" $
   parseErrors variable "return" @?= ["'return' is a reserved keyword"]

--- a/test/Bugs/Bug9.hs
+++ b/test/Bugs/Bug9.hs
@@ -7,16 +7,15 @@ import           Text.Parsec.Language           (haskellStyle)
 import           Text.Parsec.String             (Parser)
 import qualified Text.Parsec.Token              as P
 
-import           Test.Framework
-import           Test.Framework.Providers.HUnit
-import           Test.HUnit                     hiding (Test)
+import           Test.Tasty
+import           Test.Tasty.HUnit
 
 import           Util
 
 data Expr = Const Integer | Op Expr Expr
   deriving Show
 
-main :: Test
+main :: TestTree
 main =
   testCase "Tracing of current position in error message (#9)"
   $ result @?= ["unexpected '>'","expecting operator or end of input"]

--- a/test/Features.hs
+++ b/test/Features.hs
@@ -2,11 +2,11 @@ module Features
        ( features
        ) where
 
-import Test.Framework
+import Test.Tasty
 
 import qualified Features.Feature80
 
-features :: [Test]
+features :: [TestTree]
 features = [
              Features.Feature80.main
            ]

--- a/test/Features/Feature80.hs
+++ b/test/Features/Feature80.hs
@@ -4,13 +4,12 @@ import           Control.Applicative            (pure)
 import           Control.Monad.Identity
 import           Data.List.NonEmpty
 import           Data.Semigroup
-import           Test.Framework
-import           Test.Framework.Providers.HUnit
-import           Test.HUnit                     hiding (Test)
+import           Test.Tasty
+import           Test.Tasty.HUnit
 
 import           Text.Parsec
 
-main :: Test
+main :: TestTree
 main =
   testCase "Monoid instance (#80)" $ do
     parseString (as <> bs) "aabbb" @?= "aabbb"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,12 +1,12 @@
 
-import Test.Framework
+import Test.Tasty
 
 import Bugs ( bugs )
 import Features ( features )
 
 main :: IO ()
 main = do
-  defaultMain
+  defaultMain $ testGroup "All"
     [ testGroup "Bugs" bugs
     , testGroup "Features" features
     ]


### PR DESCRIPTION
`text-2.0` is not yet released, but I would like to update `parsec` HEAD so that we can bump `text` submodule in GHC source tree and start patching of `head.hackage` to iron out potential migration issues before a final release. 

Tested with 

```cabal
packages: .
tests: True

source-repository-package
  type: git
  location: https://github.com/haskell/text.git
  tag: 3488190f25e1ee5a5dea6b1a593d8a5819e76a1e
```

This builds upon https://github.com/haskell/parsec/pull/134