### PR TITLE
re-add tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Some links:
   chapter 16 of [Real World Haskell](http://book.realworldhaskell.org/).
 * [An introduction to the Parsec library](http://kunigami.wordpress.com/2014/01/21/an-introduction-to-the-parsec-library)
   on Kunigami's blog.
+* [An introduction to parsing text in Haskell with Parsec](https://jsdw.me/posts/haskell-parsec-basics/) on Wilson's blog.
 * Differences between Parsec and
   [Attoparsec](http://hackage.haskell.org/package/attoparsec)
   (Haskell's other prominent parser library) as explained in


### PR DESCRIPTION
I removed a broken tutorial README link in https://github.com/haskell/parsec/pull/156, but @fishtreesugar mentions the new location in https://github.com/haskell/parsec/pull/156#issuecomment-1123155408 .