### PR TITLE
Avoid Data.List.{head,tail}

### DIFF
--- a/src/Text/Parsec/Error.hs
+++ b/src/Text/Parsec/Error.hs
@@ -187,16 +187,16 @@ showErrorMessages msgOr msgUnknown msgExpecting msgUnExpected msgEndOfInput msgs
       (unExpect,msgs2)    = span ((UnExpect    "") ==) msgs1
       (expect,messages)   = span ((Expect      "") ==) msgs2
 
-      showExpect      = showMany msgExpecting expect
-      showUnExpect    = showMany msgUnExpected unExpect
-      showSysUnExpect | not (null unExpect) ||
-                        null sysUnExpect = ""
-                      | null firstMsg    = msgUnExpected ++ " " ++ msgEndOfInput
-                      | otherwise        = msgUnExpected ++ " " ++ firstMsg
-          where
-              firstMsg  = messageString (head sysUnExpect)
+      showSysUnExpect
+        | not (null unExpect) = ""
+        | otherwise = case sysUnExpect of
+            SysUnExpect msg : _ ->
+                msgUnExpected ++ " " ++ (if null msg then msgEndOfInput else msg)
+            _ -> ""
 
-      showMessages      = showMany "" messages
+      showUnExpect = showMany msgUnExpected unExpect
+      showExpect   = showMany msgExpecting expect
+      showMessages = showMany "" messages
 
       -- helpers
       showMany pre msgs3 = case clean (map messageString msgs3) of

--- a/src/Text/Parsec/Error.hs
+++ b/src/Text/Parsec/Error.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE Safe #-}
 
+-- Disable {-# WARNING #-} for Data.List.head:
+{-# OPTIONS_GHC -Wno-warnings-deprecations #-}
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Text.Parsec.Error

--- a/src/Text/Parsec/Error.hs
+++ b/src/Text/Parsec/Error.hs
@@ -1,9 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE Safe #-}
 
--- Disable {-# WARNING #-} for Data.List.head:
-{-# OPTIONS_GHC -Wno-warnings-deprecations #-}
-
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Text.Parsec.Error


### PR DESCRIPTION
CLC has approved the proposal to add `{-# WARNING #-}` to `Data.List.{head,tail}` (https://github.com/haskell/core-libraries-committee/issues/87). It means that usage of `head` and `tail` will emit compile-time warnings.

This patch eliminates the only usage of `head` in `parsec`.