### PR TITLE
Bump base bound to <4.20

### DIFF
--- a/parsec.cabal
+++ b/parsec.cabal
@@ -64,7 +64,7 @@ library
         Text.ParserCombinators.Parsec.Token
 
     build-depends:
-        base       >= 4.5.1.0 && < 4.19,
+        base       >= 4.5.1.0 && < 4.20,
         mtl        >= 2.1.3.1 && < 2.4,
         bytestring >= 0.9.2.1 && < 0.12,
         text      (>= 1.2.3.0  && < 1.3)


### PR DESCRIPTION
For GHC 9.8.