### PR TITLE
Optimize instance Ord of SourcePos

### DIFF
--- a/src/Text/Parsec/Pos.hs
+++ b/src/Text/Parsec/Pos.hs
@@ -41,7 +41,12 @@ type Column     = Int
 -- 'Ord' class.
 
 data SourcePos  = SourcePos SourceName !Line !Column
-    deriving ( Eq, Ord, Data, Typeable)
+    deriving (Eq, Data, Typeable)
+
+-- | The ordering compares first by line, column, then by sourcename.
+instance Ord SourcePos where
+  compare (SourcePos snA lnA colA) (SourcePos snB lnB colB)
+    = lnA `compare` lnB <> colA `compare` colB <> snA `compare` snB
 
 -- | Create a new 'SourcePos' with the given source name,
 -- line number and column number.


### PR DESCRIPTION
Followup to issue #171.

This is partial remedy, aiding somewhat with "creative" users who pass the entire input into the `parse` function — both as the input, and *as its SourceName / filename*. This makes `SourceName` *arbitrarily large* — hence, comparing first by the strict-Int fields makes a lot of sense, and does help somewhat (not terribly well) according to measurements. 

@parsonsmatt I've credited you in `Co-Authored-By` — for you've made the observation about the stock-derived Ord instance in the issue thread. Feel free to raise objection if you'd not like that, I'll promptly remove. 