### PR TITLE
Bump base upper bound to <4.23

### DIFF
--- a/parsec.cabal
+++ b/parsec.cabal
@@ -79,7 +79,7 @@ library
     Text.ParserCombinators.Parsec.Token
 
   build-depends:
-      base        >=4.12.0.0 && <4.22
+      base        >=4.12.0.0 && <4.23
     , bytestring  >=0.10.8.2 && <0.13
     , mtl         >=2.2.2    && <2.4
     , text        >=1.2.3.0  && <1.3  || >=2.0 && <2.2


### PR DESCRIPTION
Allowing GHC 9.14.